### PR TITLE
Protobuf upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: eu.gcr.io/carbon-1287/circleci-toolbox-image-java11
+        auth:
+          username: _json_key
+          password: $GCLOUD_SERVICE_KEY
+    environment:
+      MAVEN_OPTS: -Xmx3G
+    steps:
+      - checkout
+      - restore_cache:
+          key: dep-cache-{{ checksum "pom.xml" }}
+      - run: mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.0:go-offline -s /tools/m2/settings.xml
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: dep-cache-{{ checksum "pom.xml" }}
+      # Cannot use -o because of snapshot dependencies.
+      - run: mvn test -s /tools/m2/settings.xml
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
+  deploy-nexus:
+    docker:
+      - image: eu.gcr.io/carbon-1287/circleci-toolbox-image-java11
+        auth:
+          username: _json_key
+          password: $GCLOUD_SERVICE_KEY
+    environment:
+      MAVEN_OPTS: -Xmx3G
+    steps:
+      - checkout
+      - restore_cache:
+          key: dep-cache-{{ checksum "pom.xml" }}
+      - run: mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.0:go-offline -s /tools/m2/settings.xml
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: dep-cache-{{ checksum "pom.xml" }}
+      # Cannot use -o because of snapshot dependencies.
+      - run: mvn deploy -s /tools/m2/settings.xml -DskipTests
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - test:
+          context: org-carbon
+      - deploy-nexus:
+          context: org-carbon
+          requires:
+            - test
+          filters:
+            branches:
+              only: entur_develop

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>crosby.binary</groupId>
@@ -13,7 +13,7 @@
   <licenses>
     <license>
       <name>GNU General Lesser Public License (LGPL) version 3.0</name>
-      <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+	  <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -25,10 +25,10 @@
   <build>
     <sourceDirectory>${basedir}/src.java</sourceDirectory>
 
-    <resources><resource><directory>${basedir}/resources</directory></resource></resources>
+   <resources><resource><directory>${basedir}/resources</directory></resource></resources>
 
     <plugins>
-      <plugin>
+	  <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
@@ -72,7 +72,5 @@
       <artifactId>protobuf-java</artifactId>
       <version>3.8.0</version>
     </dependency>
-
-
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>crosby.binary</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.4-protobuf-3.8.0</version>
+  <version>1.3.3-protobuf-3.8.0</version>
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/scrosby/OSM-binary</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>crosby.binary</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.3</version>
+  <version>1.3.4-protobuf-3.8.0</version>
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/scrosby/OSM-binary</url>
   <licenses>
     <license>
       <name>GNU General Lesser Public License (LGPL) version 3.0</name>
-	  <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+      <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -23,49 +23,41 @@
   </scm>
 
   <build>
-	<sourceDirectory>${basedir}/src.java</sourceDirectory>
-    <outputDirectory>${basedir}/build</outputDirectory>
+    <sourceDirectory>${basedir}/src.java</sourceDirectory>
 
-   <resources><resource><directory>${basedir}/resources</directory></resource></resources>
+    <resources><resource><directory>${basedir}/resources</directory></resource></resources>
 
     <plugins>
-	  <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
 
       <plugin>
-        <groupId>com.google.protobuf.tools</groupId>
-        <artifactId>maven-protoc-plugin</artifactId>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.8.0</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
             <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
             <configuration>
-              <protoSourceRoot>${basedir}/src</protoSourceRoot>
-              <includes>
-                <param>**/*.proto</param>
-              </includes>
+              <inputDirectories>
+                <include>src</include>
+              </inputDirectories>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>dtrott</id>
-      <url>http://maven.davidtrott.com/repository</url>
-    </pluginRepository>
-  </pluginRepositories> 
 
   <dependencies>
     <dependency>
@@ -78,7 +70,10 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.4.1</version>
+      <version>3.8.0</version>
     </dependency>
+
+
+
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,5 @@
     </dependency>
 
 
-
   </dependencies>
 </project>

--- a/src/fileformat.proto
+++ b/src/fileformat.proto
@@ -15,7 +15,7 @@
 
 */
 
-option optimize_for = LITE_RUNTIME;
+syntax = "proto2";
 option java_package = "crosby.binary";
 package OSMPBF;
 

--- a/src/osmformat.proto
+++ b/src/osmformat.proto
@@ -15,7 +15,7 @@
 
 */
 
-option optimize_for = LITE_RUNTIME;
+syntax = "proto2";
 option java_package = "crosby.binary";
 package OSMPBF;
 


### PR DESCRIPTION
- Upgraded to protobuf 3.8.0
- Removed Protobuf Lite optimization (the latest version of the Protobuf Lite runtime breaks compatibility by marking some methods as final)
- Upgraded compilation target to Java 11
- Replaced Maven plugin com.google.protobuf.tools.maven-protoc-plugin by com.github.os72.protoc-jar-maven-plugin to enable platform-independant compilation