### PR TITLE
add wagon to deploy to Conveyal Maven repo on S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/*.pb.o
 src/libosmpbf.a
 *.swp
 obj-x86_64-linux-gnu
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,16 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  
   <groupId>crosby.binary</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.3-protobuf-3.8.0</version>
+  <version>1.3.3-entur</version>
+  
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/scrosby/OSM-binary</url>
+ 
   <licenses>
     <license>
       <name>GNU General Lesser Public License (LGPL) version 3.0</name>
@@ -17,6 +20,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+ 
   <scm>
     <url>https://github.com/scrosby/OSM-binary</url>
     <connection>https://github.com/scrosby/OSM-binary.git</connection>
@@ -24,16 +28,26 @@
 
   <distributionManagement>
     <repository>
-      <id>snapshots</id>
-      <name>entur2-releases</name>
-      <url>https://entur2.jfrog.io/entur2/libs-release-local</url>
+      <id>conveyal-s3</id>
+      <name>Conveyal Maven Repository on AWS S3</name>
+      <url>s3://maven.conveyal.com</url>
     </repository>
   </distributionManagement>
 
   <build>
     <sourceDirectory>${basedir}/src.java</sourceDirectory>
 
-   <resources><resource><directory>${basedir}/resources</directory></resource></resources>
+    <resources><resource><directory>${basedir}/resources</directory></resource></resources>
+
+    <extensions>
+      <!-- This wagon does multi-threaded upload to S3. -->
+      <!-- You can set credentials in environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_KEY -->
+      <extension>
+        <groupId>org.kuali.maven.wagons</groupId>
+        <artifactId>maven-s3-wagon</artifactId>
+        <version>1.2.1</version>
+      </extension>
+    </extensions>
 
     <plugins>
 	  <plugin>


### PR DESCRIPTION
As discussed on Slack, I have modified the POM to deploy artifacts to the Conveyal S3-based Maven repo. I have already run the build and deployed it, so you should be able to use OSM-binary version `1.3.3-entur` as a dependency as long as your project includes the Conveyal Maven repo:

```
        <repository>
            <id>conveyal</id>
            <name>conveyal</name>
            <url>https://maven.conveyal.com</url>
        </repository>
``` 